### PR TITLE
update versions in stage2 manifest to reflect stage1

### DIFF
--- a/aws/dev/dev-us-west-2-core-stage1.yaml
+++ b/aws/dev/dev-us-west-2-core-stage1.yaml
@@ -23,7 +23,6 @@ inbound_data_plane_node_group_instance_types:
   - m5.xlarge
 inbound_data_plane_node_group_max_size: 6
 
-outbound_vpc_cidr: 10.0.4.0/22
 outbound_data_plane_node_group_instance_types:
   - m5.xlarge
 outbound_data_plane_node_group_max_size: 6

--- a/aws/dev/dev-us-west-2-core-stage2.yaml
+++ b/aws/dev/dev-us-west-2-core-stage2.yaml
@@ -10,11 +10,11 @@ private_connect_role_name: dev-core-stage2-us-west-2-private-connect
 api_authorization: CUSTOM
 api_authorizer_gdot_url: https://cloudatlas.salesforce.com/services/c2c/api/v1/validateJwt
 api_authorizer_c2c_key_secret_name: C2C-EC-Keys-Prod
-#api_access_whitelist_ips:
+api_access_whitelist_ips:
   # Monitoring VM
-  #- 44.233.159.220/32
-lambda_layer_s3_key: zip/cni_common-udmalpe-b062e5d7-f07f-4097-93ba-d6e5d91c55cb.zip
-lambda_function_s3_key: zip/api_v1.zip
+  - 54.244.135.104/32
+lambda_layer_s3_key: zip/cni_common_v226-6.zip
+lambda_function_s3_key: zip/api_v4.zip
 lambda_memory_size: 2048
 
 eks_k8s_version: '1.15'
@@ -35,10 +35,10 @@ monitoring:
   version: '4'
 dataplane_inbound:
   image: 985884022631.dkr.ecr.us-west-2.amazonaws.com/cni-nginx-proxy-inbound
-  version: '19'
+  version: '7'
 dataplane_outbound:
   image: 985884022631.dkr.ecr.us-west-2.amazonaws.com/cni-nginx-proxy-outbound
-  version: '19'
+  version: '7'
 outbound_vpcs_config:
   1:
     vpc_cidr: 10.200.0.0/16


### PR DESCRIPTION
This updates the stage2 manifest so it has the same code and image versions as stage1 (with the exception of using 266_v6 for lambda code).